### PR TITLE
Revamp dashboard UI and fix AI analyst formatting

### DIFF
--- a/varavu_selavu_ui/src/components/ai-analyst/AIAnalystChat.tsx
+++ b/varavu_selavu_ui/src/components/ai-analyst/AIAnalystChat.tsx
@@ -73,6 +73,15 @@ export default function AIAnalystChat({ userId, startDate, endDate }: AIAnalystC
 
   const scopeLabel = `${startDate} to ${endDate}`;
 
+  const formatMarkdown = (text: string) => {
+    return text
+      .replace(/\n\n/g, '<br/><br/>')
+      .replace(/\n/g, '<br/>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .replace(/`([^`]+)`/g, '<code>$1</code>');
+  };
+
   return (
     <div className="ai-analyst-chat" style={{ maxWidth: 600, margin: '0 auto', padding: 8 }}>
       <h3 style={{ fontSize: 20, marginBottom: 12 }}>Ask the AI Analyst — {scopeLabel}</h3>
@@ -119,7 +128,10 @@ export default function AIAnalystChat({ userId, startDate, endDate }: AIAnalystC
           }}
         >
           <strong>Answer:</strong>
-          <p style={{ margin: 0 }}>{response}</p>
+          <div
+            style={{ margin: 0 }}
+            dangerouslySetInnerHTML={{ __html: formatMarkdown(response) }}
+          />
         </div>
       )}
     </div>

--- a/varavu_selavu_ui/src/components/dashboard/CategoryBreakdownSunburst.tsx
+++ b/varavu_selavu_ui/src/components/dashboard/CategoryBreakdownSunburst.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Card, CardContent, Typography } from '@mui/material';
+import Plot from 'react-plotly.js';
+
+interface CategoryTotal {
+  category: string;
+  total: number;
+}
+
+interface Props {
+  data: CategoryTotal[];
+}
+
+const CategoryBreakdownSunburst: React.FC<Props> = ({ data }) => {
+  const labels = data.map(d => d.category);
+  const parents = labels.map(() => '');
+  const values = data.map(d => d.total);
+  return (
+    <Card
+      sx={{
+        height: '100%',
+        backdropFilter: 'blur(6px)',
+        background: 'rgba(255,255,255,0.4)',
+        border: '1px solid rgba(255,255,255,0.2)',
+        animation: 'fadeIn 0.5s ease'
+      }}
+    >
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          Category Breakdown
+        </Typography>
+        <Plot
+          data={[{ type: 'sunburst', labels, parents, values, branchvalues: 'total' }]}
+          layout={{ margin: { l: 0, r: 0, t: 0, b: 0 }, height: 250 }}
+          style={{ width: '100%' }}
+        />
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CategoryBreakdownSunburst;

--- a/varavu_selavu_ui/src/components/dashboard/MetricCard.tsx
+++ b/varavu_selavu_ui/src/components/dashboard/MetricCard.tsx
@@ -10,7 +10,19 @@ interface MetricCardProps {
 
 const MetricCard: React.FC<MetricCardProps> = ({ label, value }) => {
   return (
-    <Card sx={{ minWidth: 140, flex: 1, m: { xs: 0.5, md: 1 }, boxShadow: 3, width: '100%', maxWidth: 340 }}>
+    <Card
+      sx={{
+        minWidth: 140,
+        flex: 1,
+        m: { xs: 0.5, md: 1 },
+        width: '100%',
+        maxWidth: 340,
+        backdropFilter: 'blur(6px)',
+        background: 'rgba(255,255,255,0.4)',
+        border: '1px solid rgba(255,255,255,0.2)',
+        animation: 'fadeIn 0.5s ease',
+      }}
+    >
       <CardContent>
         <Typography color="text.secondary" gutterBottom>
           {label}

--- a/varavu_selavu_ui/src/components/dashboard/QuickAddExpenseCard.tsx
+++ b/varavu_selavu_ui/src/components/dashboard/QuickAddExpenseCard.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import {
+  Card,
+  CardContent,
+  Typography,
+  TextField,
+  Button
+} from '@mui/material';
+import { addExpense } from '../../api/expenses';
+import { isoToMMDDYYYY } from '../../utils/date';
+
+interface Props {
+  onAdded?: () => void;
+}
+
+const QuickAddExpenseCard: React.FC<Props> = ({ onAdded }) => {
+  const [date, setDate] = useState(new Date().toISOString().split('T')[0]);
+  const [category, setCategory] = useState('');
+  const [description, setDescription] = useState('');
+  const [amount, setAmount] = useState('');
+  const [saving, setSaving] = useState(false);
+  const user = typeof window !== 'undefined' ? localStorage.getItem('vs_user') : null;
+
+  const handleAdd = async () => {
+    if (!user) return;
+    setSaving(true);
+    try {
+      await addExpense({
+        user_id: user,
+        date: isoToMMDDYYYY(date),
+        description,
+        category,
+        cost: parseFloat(amount) || 0,
+      });
+      setCategory('');
+      setDescription('');
+      setAmount('');
+      onAdded?.();
+    } catch {
+      // ignore errors for quick add
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card
+      sx={{
+        backdropFilter: 'blur(6px)',
+        background: 'rgba(255,255,255,0.4)',
+        border: '1px solid rgba(255,255,255,0.2)',
+        animation: 'fadeIn 0.5s ease'
+      }}
+    >
+      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+        <Typography variant="h6" gutterBottom>
+          Quick Add Expense
+        </Typography>
+        <TextField size="small" type="date" value={date} onChange={e => setDate(e.target.value)} />
+        <TextField size="small" label="Category" value={category} onChange={e => setCategory(e.target.value)} />
+        <TextField size="small" label="Description" value={description} onChange={e => setDescription(e.target.value)} />
+        <TextField size="small" label="Amount" type="number" value={amount} onChange={e => setAmount(e.target.value)} />
+        <Button variant="contained" onClick={handleAdd} disabled={saving || !user}>
+          {saving ? 'Adding...' : 'Add'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default QuickAddExpenseCard;

--- a/varavu_selavu_ui/src/components/dashboard/RecentActivityList.tsx
+++ b/varavu_selavu_ui/src/components/dashboard/RecentActivityList.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import Card from '@mui/material/Card';
-import CardContent from '@mui/material/CardContent';
-import Typography from '@mui/material/Typography';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
-import ListItemAvatar from '@mui/material/ListItemAvatar';
-import Avatar from '@mui/material/Avatar';
-import ListItemText from '@mui/material/ListItemText';
-import { parseMMDDYYYY } from '../../utils/date';
+import {
+  Card,
+  CardContent,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow
+} from '@mui/material';
 
 interface Activity {
   date: string;
@@ -21,28 +22,46 @@ interface Props {
 }
 
 const RecentActivityList: React.FC<Props> = ({ items }) => (
-  <Card sx={{ height: '100%' }}>
+  <Card
+    sx={{
+      height: '100%',
+      backdropFilter: 'blur(6px)',
+      background: 'rgba(255,255,255,0.4)',
+      border: '1px solid rgba(255,255,255,0.2)',
+      animation: 'fadeIn 0.5s ease'
+    }}
+  >
     <CardContent>
       <Typography variant="h6" gutterBottom>
-        Recent Activity
+        Recent Transactions
       </Typography>
-      <List dense>
-        {items.map(item => (
-          <ListItem key={`${item.date}-${item.description}`}
-            secondaryAction={
-              <Typography variant="body2">${item.cost.toFixed(2)}</Typography>
-            }
-          >
-            <ListItemAvatar>
-              <Avatar>{item.category.charAt(0)}</Avatar>
-            </ListItemAvatar>
-            <ListItemText primary={item.description} secondary={parseMMDDYYYY(item.date).toLocaleDateString()} />
-          </ListItem>
-        ))}
-        {items.length === 0 && (
-          <Typography color="text.secondary">No recent transactions</Typography>
-        )}
-      </List>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Date</TableCell>
+            <TableCell>Category</TableCell>
+            <TableCell>Description</TableCell>
+            <TableCell align="right">Amount</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {items.map((item) => (
+            <TableRow key={`${item.date}-${item.description}`}>
+              <TableCell>{new Date(item.date).toLocaleDateString()}</TableCell>
+              <TableCell>{item.category}</TableCell>
+              <TableCell>{item.description}</TableCell>
+              <TableCell align="right">${item.cost.toFixed(2)}</TableCell>
+            </TableRow>
+          ))}
+          {items.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={4} align="center">
+                <Typography color="text.secondary">No recent transactions</Typography>
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
     </CardContent>
   </Card>
 );

--- a/varavu_selavu_ui/src/index.css
+++ b/varavu_selavu_ui/src/index.css
@@ -12,3 +12,14 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/varavu_selavu_ui/src/pages/DashboardPage.tsx
+++ b/varavu_selavu_ui/src/pages/DashboardPage.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import MetricCard from '../components/dashboard/MetricCard';
-import MonthlyTrendChart from '../components/dashboard/MonthlyTrendChart';
-import TopCategoriesChart from '../components/dashboard/TopCategoriesChart';
 import RecentActivityList from '../components/dashboard/RecentActivityList';
+import CategoryBreakdownSunburst from '../components/dashboard/CategoryBreakdownSunburst';
+import QuickAddExpenseCard from '../components/dashboard/QuickAddExpenseCard';
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { getAnalysis, AnalysisResponse } from '../api/analysis';
-import { parseMMDDYYYY } from '../utils/date';
 
 const DashboardPage: React.FC = () => {
   const [data, setData] = React.useState<AnalysisResponse | null>(null);
@@ -41,40 +40,62 @@ const DashboardPage: React.FC = () => {
   const expenses = data.category_expense_details
     ? Object.values(data.category_expense_details).flat()
     : [];
-  const largest = expenses.reduce((max, e) => (e.cost > max.cost ? e : max), { cost: 0 } as any);
+  const now = new Date();
+  const thisMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const thisMonthTotal = data.monthly_trend.find(m => m.month === thisMonthKey)?.total || 0;
+  const weekAgo = new Date();
+  weekAgo.setDate(now.getDate() - 7);
+  const thisWeekTotal = expenses
+    .filter(e => new Date(e.date) >= weekAgo && new Date(e.date) <= now)
+    .reduce((sum, e) => sum + e.cost, 0);
   const recent = [...expenses]
-    .sort((a, b) => parseMMDDYYYY(b.date).getTime() - parseMMDDYYYY(a.date).getTime())
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
     .slice(0, 5);
 
+  const last3Start = new Date();
+  last3Start.setMonth(now.getMonth() - 2);
+  const last3Totals: Record<string, number> = {};
+  expenses.forEach(e => {
+    const d = new Date(e.date);
+    if (d >= last3Start) {
+      last3Totals[e.category] = (last3Totals[e.category] || 0) + e.cost;
+    }
+  });
+  const sunburstData = Object.entries(last3Totals).map(([category, total]) => ({ category, total }));
+
+  const fetchData = async () => {
+    const user = localStorage.getItem('vs_user');
+    if (!user) return;
+    const resp = await getAnalysis(user, { year });
+    setData(resp);
+  };
+
   return (
-    <Box>
-      <Grid container columns={12} spacing={2} justifyContent="center" alignItems="stretch" sx={{ mb: 2 }}>
-        <Grid size={{ xs: 12, md: 3 }}>
-          <MetricCard label="💸 Total Expenses (YTD)" value={`$${data.total_expenses.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`} />
+    <Box sx={{ animation: 'fadeIn 0.5s ease' }}>
+      <Grid container columns={12} spacing={2} sx={{ mb: 2 }}>
+        <Grid size={{ xs: 12, md: 4 }}>
+          <MetricCard label="Total Expenses" value={`$${data.total_expenses.toFixed(2)}`} />
         </Grid>
-        <Grid size={{ xs: 12, md: 3 }}>
-          <MetricCard label="📊 Total Categories" value={data.category_totals.length} />
+        <Grid size={{ xs: 12, md: 4 }}>
+          <MetricCard label="This Month" value={`$${thisMonthTotal.toFixed(2)}`} />
         </Grid>
-        <Grid size={{ xs: 12, md: 3 }}>
-          <MetricCard label="📅 Months Tracked" value={new Set(data.monthly_trend.map(m => m.month)).size} />
-        </Grid>
-        <Grid size={{ xs: 12, md: 3 }}>
-          <MetricCard label="🏆 Largest Transaction" value={largest.cost ? `$${largest.cost.toFixed(2)}` : '$0.00'} />
+        <Grid size={{ xs: 12, md: 4 }}>
+          <MetricCard label="This Week" value={`$${thisWeekTotal.toFixed(2)}`} />
         </Grid>
       </Grid>
-      <Grid container columns={12} spacing={2} justifyContent="center">
-        <Grid size={{ xs: 12 }}>
-          <MonthlyTrendChart monthlyTrend={data.monthly_trend} />
-        </Grid>
-      </Grid>
-      <Grid container columns={12} spacing={2} justifyContent="center" sx={{ mt: 2 }}>
-        <Grid size={{ xs: 12 }}>
-          <TopCategoriesChart categoryTotals={data.category_totals} />
-        </Grid>
-      </Grid>
-      <Grid container columns={12} spacing={2} justifyContent="center" sx={{ mt: 2 }}>
-        <Grid size={{ xs: 12, md: 6 }}>
+      <Grid container columns={12} spacing={2} sx={{ mt: 1 }}>
+        <Grid size={{ xs: 12, md: 8 }}>
           <RecentActivityList items={recent} />
+        </Grid>
+        <Grid size={{ xs: 12, md: 4 }}>
+          <Grid container columns={12} spacing={2}>
+            <Grid size={{ xs: 12 }}>
+              <CategoryBreakdownSunburst data={sunburstData} />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <QuickAddExpenseCard onAdded={fetchData} />
+            </Grid>
+          </Grid>
         </Grid>
       </Grid>
     </Box>

--- a/varavu_selavu_ui/src/pages/ExpenseAnalysisPage.tsx
+++ b/varavu_selavu_ui/src/pages/ExpenseAnalysisPage.tsx
@@ -37,12 +37,19 @@ const ExpenseAnalysisPage: React.FC = () => {
   const monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
   const title = overallYear ? `Analysis — ${year} (Year Overview)` : `Analysis — ${monthNames[month-1]} ${year}`;
 
+  const glass = {
+    backdropFilter: 'blur(6px)',
+    background: 'rgba(255,255,255,0.4)',
+    border: '1px solid rgba(255,255,255,0.2)',
+    animation: 'fadeIn 0.5s ease',
+  } as const;
+
   return (
-    <Box sx={{ mt: 4 }}>
+    <Box sx={{ mt: 4, animation: 'fadeIn 0.5s ease' }}>
       <Grid container columns={12} spacing={2}>
         {/* Sidebar */}
         <Grid size={{ xs: 12, md: 3 }}>
-          <Paper elevation={3} sx={{ p: 2, position: { md: 'sticky' }, top: { md: 80 }, mb: { xs: 2, md: 0 } }}>
+          <Paper elevation={3} sx={{ p: 2, position: { md: 'sticky' }, top: { md: 80 }, mb: { xs: 2, md: 0 }, ...glass }}>
             <Typography variant="h6" sx={{ mb: 2 }}>Filters</Typography>
             <FormControl fullWidth size="small" sx={{ mb: 2 }}>
               <InputLabel id="year-label">Year</InputLabel>
@@ -80,19 +87,19 @@ const ExpenseAnalysisPage: React.FC = () => {
           <Typography variant="h5" sx={{ mb: 2, fontWeight: 700 }}>{title}</Typography>
 
           {data.filter_info && (
-            <Paper variant="outlined" sx={{ p: 1.5, mb: 2, bgcolor: '#fafafa' }}>
+            <Paper variant="outlined" sx={{ p: 1.5, mb: 2, bgcolor: '#fafafa', ...glass }}>
               <Typography variant="caption" color="text.secondary">
                 Filters applied — user_col: {data.filter_info.applied_user_col || 'none'}, year: {String(data.filter_info.year || '')}, month: {String(data.filter_info.month || '')}, rows: {String(data.filter_info.row_count || 0)}
               </Typography>
             </Paper>
           )}
 
-          <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
+          <Paper elevation={2} sx={{ p: 2, mb: 2, ...glass }}>
             <Typography variant="h6" sx={{ mb: 1 }}>Summary</Typography>
             <ExpenseSummaryCards totalExpenses={data.total_expenses} income={income} />
           </Paper>
 
-          <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
+          <Paper elevation={2} sx={{ p: 2, mb: 2, ...glass }}>
             <Typography variant="h6" sx={{ mb: 1 }}>Top Categories</Typography>
             <Grid container columns={12}>
               <Grid size={{ xs: 12 }}>
@@ -101,13 +108,13 @@ const ExpenseAnalysisPage: React.FC = () => {
             </Grid>
           </Paper>
 
-          <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
+          <Paper elevation={2} sx={{ p: 2, mb: 2, ...glass }}>
             <Typography variant="h6" sx={{ mb: 1 }}>Category Breakdown</Typography>
             <CategorySummaryTable categoryTotals={data.category_totals} income={income} details={data.category_expense_details || {}} />
           </Paper>
 
           {overallYear ? (
-            <Paper elevation={2} sx={{ p: 2, mb: 2 }}>
+            <Paper elevation={2} sx={{ p: 2, mb: 2, ...glass }}>
               <Typography variant="h6" sx={{ mb: 1 }}>Monthly Trend</Typography>
               <Grid container columns={12}>
                 <Grid size={{ xs: 12 }}>


### PR DESCRIPTION
## Summary
- Refresh dashboard layout with glassy metric cards, sunburst breakdown, and quick add form
- Fix recent activity list and add animation styles to dashboard and analysis pages
- Render AI analyst responses with basic Markdown formatting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: varavu_selavu_service)*
- `cd varavu_selavu_ui && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b31d0678388325899913cf5114dba9